### PR TITLE
[共通] add : eat: レスポンシブ対応でタブレットサイズを2倍表示に調整

### DIFF
--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -1,8 +1,9 @@
 <template>
+  <!-- タブレットサイズ(768px以上)の場合、フォントサイズを3xlに、それ以外の場合はxlに設定 -->
   <button
     @click="$emit('press', label)"
     :class="[
-      'font-bold rounded-full text-xl w-16 h-16 flex items-center justify-center transition-all duration-200'
+      'font-bold rounded-full text-xl md:text-3xl lg:text-xl w-16 h-16 md:w-32 md:h-32 lg:w-16 lg:h-16 flex items-center justify-center transition-all duration-200'
     ]"
     :style="buttonStyle"
   >
@@ -43,7 +44,6 @@ export default defineComponent({
         }
       }
     })
-    
     return { buttonStyle }
   }
 })
@@ -53,6 +53,14 @@ export default defineComponent({
 button {
   border: none;
   cursor: pointer;
+  font-size: 1.25rem; /* SP/PCサイズ */
+}
+
+/* タブレットサイズ（768px以上）でフォントサイズを大きく */
+@media (min-width: 768px) and (max-width: 1023px) {
+  button {
+    font-size: 1.875rem; /* text-3xl相当 */
+  }
 }
 
 button:hover {

--- a/src/components/Calculator.vue
+++ b/src/components/Calculator.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="calculator-container bg-gray-800 p-4 rounded-xl shadow-lg w-[320px] mx-auto">
+	<!-- タブレットサイズ(768px以上)の場合、幅を640pxに、それ以外の場合は320pxに設定 -->
+  <div class="calculator-container bg-gray-800 p-4 md:p-8 lg:p-4 rounded-xl shadow-lg w-[320px] md:w-[640px] lg:w-[320px] mx-auto">
 		<!-- Displayコンポーネントに、displayValue(表示する値)を渡す -->
 		<Display :value="output" />
 		<!-- KeypadコンポーネントにhandleButtonPressをカスタムイベントとして渡す -->

--- a/src/components/Display.vue
+++ b/src/components/Display.vue
@@ -1,5 +1,6 @@
 <template>
-	<div class="display bg-black text-white text-2xl p-4 rounded-md mb-4 text-right font-mono overflow-x-auto">
+	<!-- タブレットサイズ(768px以上)の場合、フォントサイズを3xlに、それ以外の場合は2xlに設定 -->
+	<div class="display bg-black text-white text-2xl md:text-3xl lg:text-2xl p-4 md:p-8 lg:p-4 rounded-md mb-4 md:mb-8 lg:mb-4 text-right font-mono overflow-x-auto">
 		{{ value }}
 	</div>
 </template>

--- a/src/components/Keypad.vue
+++ b/src/components/Keypad.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="grid grid-cols-4 gap-2">
+	<!-- タブレットサイズ(768px以上)の場合、グリッドの列数を4に、それ以外の場合2に設定 -->
+  <div class="grid grid-cols-4 gap-2 md:gap-4 lg:gap-2">
 		<Button
 			v-for="key in keys"
 			:key="key"


### PR DESCRIPTION
- 計算機の幅を320px → タブレット(768px)で640px、PC(1024px)で320pxに
- ボタンサイズを64px → タブレットで128px、PCで64pxに
- フォントサイズをtext-xl → タブレットでtext-3xl、PCでtext-xlに
- ディスプレイとパディングも比例して調整
- CSSメディアクエリでタブレット専用のフォントサイズ制御を追加 (Button )